### PR TITLE
Add link to GH Issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 * ガイドが更新されたり、バージョンが変わったりして不要になったissueは、気がついた人がissueをcloseしてください
 
 issueテンプレート：  
-https://github.com/railsgirls-jp/coach.info/issues/new?&body=%23%23%20バージョン%0A%2a%20OS:%0A%2a%20Ruby:%0A%2a%20Rails:%0A%0A%23%23%20背景%0A%0A%23%23%20詳細%0A%0A%23%23%20解決方法など%0A%0A
+https://github.com/railsgirls-jp/coach.info/issues/new?&body=%23%23%20バージョン%0A%2a%20OS:%0A%2a%20Ruby:%0A%2a%20Rails:%0A%2a%20本家Issue:%0A%0A%23%23%20背景%0A%0A%23%23%20詳細%0A%0A%23%23%20解決方法など%0A%0A
 
 この運用方法も、改善等あれば随時追加、編集してください。  
 よろしくお願いいたします。


### PR DESCRIPTION
ここにIssueとして置いてあるだけだとずっと本家で解決しない(運用回避しか取れない)のでissueテンプレートに本家Issueへのリンクを追加しました。
